### PR TITLE
Accept large values for UnsignedData.age

### DIFF
--- a/Smith.MatrixSdk/ApiTypes/Sync.cs
+++ b/Smith.MatrixSdk/ApiTypes/Sync.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -278,7 +278,7 @@ namespace Smith.MatrixSdk.ApiTypes
     /// </param>
     public record UnsignedData
     (
-        int? Age,
+        long? Age,
         Event? RedactedBecause,
         string? TransactionId
     );


### PR DESCRIPTION
While running the example project against my account, I got a room event
that's over 3 years old. The program failed to deserialize it because
the value is too large for an `int` (2^31 milliseconds is less than
a month).

This commit changes the field to `long`, which can represent millions of
years.