### PR TITLE
Make it possible to terminate Example with ^C

### DIFF
--- a/Smith.MatrixSdk.Example/Application.cs
+++ b/Smith.MatrixSdk.Example/Application.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ConsoleAppFramework;
 using JetBrains.Annotations;
@@ -13,24 +14,32 @@ namespace Smith.MatrixSdk.Example
     {
         private readonly ILogger _logger;
         private readonly HttpClient _httpClient;
+        private readonly CancellationTokenSource _ctrl_c_cts;
 
         public Application(ILogger<Application> logger, HttpClient httpClient)
         {
             _logger = logger;
             _httpClient = httpClient;
+            _ctrl_c_cts = new CancellationTokenSource();
+
+            Console.CancelKeyPress += delegate {
+                _ctrl_c_cts.Cancel();
+            };
         }
 
         [UsedImplicitly]
         public async Task Run(string user, string password, string homeserver = "https://matrix.org")
         {
             var client = new MatrixClient(_logger, _httpClient, new Uri(homeserver));
-            var loginResponse = await client.Login(user, password);
+            var loginResponse = await client.Login(user, password, _ctrl_c_cts.Token);
             Console.WriteLine(loginResponse);
 
             await client.StartEventPolling(loginResponse.AccessToken.NotNull(), TimeSpan.FromSeconds(5))
                 .Do(syncResponse =>
                 {
                     Console.WriteLine($"Next batch: {syncResponse.NextBatch}");
+
+                    _ctrl_c_cts.Token.ThrowIfCancellationRequested();
                 });
         }
     }


### PR DESCRIPTION
Please note I'm new to .NET and C#, so this implementation might be completely stupid.

The only alternative I'm aware of is `Console.TreatControlCAsInput` property; setting it to `false` should've made ^C to kill the app immediately, but this doesn't happen even though `false` is supposedly the default. Anyway, terminating with cancellation tokens is more graceful, so I tried that instead of investigating `TreatConrolCAsInput` further.